### PR TITLE
change INSTALL_PATH from `usr/bin` to `bin`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ include_directories(include)
 
 include_directories(include)
 file(GLOB SOURCES "src/*.c")
-SET(INSTALL_PATH "usr/bin")
+SET(INSTALL_PATH "bin")
 
 # Declare the executable target built from your sources
 add_executable(axi-qos ${SOURCES})
@@ -51,4 +51,3 @@ set(CPACK_PACKAGING_INSTALL_PREFIX "/")
 set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_PACKAGE_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}")
 set(CPACK_RPM_SPEC_MORE_DEFINE "%define _build_id_links none")
 include(CPack)
-


### PR DESCRIPTION
During debian package build it already gives installation prefix as /usr so at the end it becomes /usr/usr/bin which is incorrect path for the installation of binaries.

So to fix this problem installation path needs to be set as `bin`